### PR TITLE
README 修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@
         uid=9999(user_name) gid=9999(group_name) groups=9999(group_name)
         ```
 
-    - `.env.template`をコピペして`.env`を作成して先ほど調べたuser_name, uid, gidを記述
+    - `.env.example`をコピペして`.env`を作成して先ほど調べたuser_name, uid, gidを記述
 
         ```
         USER_NAME=user_name


### PR DESCRIPTION
PyTorch × Docker 環境のご共有ありがとうございます！

README.md に「`.env.template` をコピペして `.env` を作成」とありましたが、存在するのは `.env.example` であったため README 側をファイル名にあわせて修正しました。